### PR TITLE
#inc-5312 fixing item image for product catalog

### DIFF
--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -45,7 +45,7 @@ class Item extends React.Component {
       this.props.currentUser &&
       this.props.currentUser.username === this.props.item.seller.username;
 
-    const imageUrl = this.props.item.image || "../placeholder.png"
+    const imageUrl = this.props.item.image || "../placeholder.png";
     return (
       <div className="container page" id="item-container">
         <div className="text-dark">

--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -44,13 +44,15 @@ class Item extends React.Component {
     const canModify =
       this.props.currentUser &&
       this.props.currentUser.username === this.props.item.seller.username;
+
+    const imageUrl = this.props.item.image || "../placeholder.png"
     return (
       <div className="container page" id="item-container">
         <div className="text-dark">
           <div className="row bg-white p-4">
             <div className="col-6">
               <img
-                src={this.props.item.image}
+                src={imageUrl}
                 alt={this.props.item.title}
                 className="item-img"
                 style={{ height: "500px", width: "100%", borderRadius: "6px" }}

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -19,7 +19,7 @@ const mapDispatchToProps = (dispatch) => ({
 
 const ItemPreview = (props) => {
   const item = props.item;
-  const imageUrl = item.image || "./placeholder.png"
+  const imageUrl = item.image || "./placeholder.png";
 
   const handleClick = (ev) => {
     ev.preventDefault();

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -19,6 +19,7 @@ const mapDispatchToProps = (dispatch) => ({
 
 const ItemPreview = (props) => {
   const item = props.item;
+  const imageUrl = item.image || "./placeholder.png"
 
   const handleClick = (ev) => {
     ev.preventDefault();
@@ -36,7 +37,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={imageUrl}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
# Description

I fixed broken image with the placeholder image on the frontend side in two different previews:
 - in catalog preview where you see all the items in the catalog
 - in item preview 
In case the backend doesn't have an image it will just load the local placeholder whi

I thought about fixing this when a new Item is created and to upload this image as the initial image but this will just cause this image to be uploaded over and over again and storage is expensive, it is also will not fix all the items with an empty image that are already stored in the db. It could also be possible that the backend is used by different client which will have a different placeholder image.
<img width="1388" alt="Screenshot 2022-11-27 at 10 39 16" src="https://user-images.githubusercontent.com/3968498/204126297-41b02292-f2c3-4429-9cd5-d649526d9ad1.png">
<img width="1312" alt="Screenshot 2022-11-27 at 10 39 00" src="https://user-images.githubusercontent.com/3968498/204126300-d22ec005-befa-4268-b872-0209830d62c8.png">


